### PR TITLE
Hackishly worked around dotnet run bug

### DIFF
--- a/DotNetRunPlatformsBug.csproj
+++ b/DotNetRunPlatformsBug.csproj
@@ -6,6 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Platforms>x64</Platforms>
+    <!-- hacked in to avoid dotnet run bug -->
+    <Platform>x64</Platform>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
dotnet build # works and builds to bin/x64/Debug,
dotnet run --no-build # works, expects binary in bin/x64/Debug like it should.

This is a workaround to the bug, not a solution, but should provide guidance in fixing it.